### PR TITLE
Activate oldest cluster when recycling.

### DIFF
--- a/pypi-dependencies.json
+++ b/pypi-dependencies.json
@@ -156,6 +156,25 @@
                     "sha256": "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
                 }
             ]
+        },
+        {
+            "name": "python3-python-dateutil",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} python-dateutil"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d4/70/d60450c3dd48ef87586924207ae8907090de0b306af2bce5d134d78615cb/python_dateutil-2.8.1-py2.py3-none-any.whl",
+                    "sha256": "75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl",
+                    "sha256": "8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+                }
+            ]
         }
     ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ xpybutil
 system_hotkey
 pyyaml
 docker
+python-dateutil

--- a/src/docker.py
+++ b/src/docker.py
@@ -99,6 +99,14 @@ class DockerController(object):
                     return c
         return None
 
+    def get_container_created(self, container) -> str:
+        """
+        Return the container IP
+
+        The network will be something like 'k3d-k3s-cluster-690'
+        """
+        return container.attrs['Created']
+
     def get_container_ip(self, container, network_name: str) -> str:
         """
         Return the container IP

--- a/src/menu.py
+++ b/src/menu.py
@@ -212,9 +212,10 @@ class K3dvMenu(Gtk.Menu):
         # check if we can activate some other random cluster
         if len(clusters) > 1:
             to_activate_name = None
-            for cluster_name in clusters.keys():
-                if current is None or cluster_name != current.name:
-                    to_activate_name = cluster_name
+            for c in sorted(clusters.values(), key=lambda x: x.docker_created):
+                if current is None or c.name != current.name:
+                    to_activate_name = c.name
+                    logging.debug(f"[MENU] Will activate '{to_activate_name}' (created at {c.docker_created})")
                     break
 
             if to_activate_name is not None:


### PR DESCRIPTION
When recycling clusters, we remove the current cluster and try to activate a random cluster. This could cause problems: the random cluster could be the most recently created one.

This solves the problem by sorting clusters by age and activating the oldest one.

Closes #7 