### PR TITLE
Add dependencies to the contributing section in README.md (#22)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ help: ## Show this help screen
 ##@ Development
 
 deps: ## Install all the required dependencies for building/running
+	@printf "$(CYN)>>> $(GRN)Checking out submodules...$(END)\n"
+	git submodule init
+	git submodule update
 	@printf "$(CYN)>>> $(GRN)Adding flatpak dependencies (apps, frameworks...)...$(END)\n"
 	flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 	flatpak --user install -y flathub $(FLATPAK_RUNTIME)/x86_64/$(FLATPAK_RUNTIME_VERSION)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ And you could also try master the global keyboard shortcuts for quicly creating/
   is available in your machine.
 * You can _fork_ and _clone_ this repo (if you plan to contribute) or just _download_
   it in some directory in your laptop.
+* Install all dependencies with:
+  ```
+  make deps
+  ```
 * Then you can run it with:
   ```console
   make run


### PR DESCRIPTION
Add all the steps the contributor needs to follow to have a working instance of
the project.
Tested on a new install of Fedora33.