### PR TITLE
Update com.github.inercia.k3x.appdata.xml.in

### DIFF
--- a/data/com.github.inercia.k3x.appdata.xml.in
+++ b/data/com.github.inercia.k3x.appdata.xml.in
@@ -7,7 +7,6 @@
   <summary>Manager for local Kubernetes clusters with k3d</summary>
   <developer_name>Alvaro Saurin</developer_name>
   <categories>
-    <category>Game</category>
     <category>GTK</category>
   </categories>
   <provides>


### PR DESCRIPTION
Remove the Game category

Hello! Here is a suggested edit. I spend a lot of time on the Flathub Games directory (https://flathub.org/apps/category/Game), and I think k3x is a miscategorized in this case:

![Screenshot 2021-12-01 at 13-14-21 Games—Linux Apps on Flathub](https://user-images.githubusercontent.com/74557/144315225-b7c2e29d-6f76-48be-a990-e9db99fe5626.png)

It likely fits in other categories, but as I'm just becoming familiar with the overall catalog I don't have any suggestions on which to add.